### PR TITLE
routerで2回遷移しないように修正

### DIFF
--- a/src/components/molecules/ResultBook/ResultBook.tsx
+++ b/src/components/molecules/ResultBook/ResultBook.tsx
@@ -29,7 +29,6 @@ export const ResultBook = (props: ResultBook) => {
   ) => {
     const encode = encodeURI(nextLink);
     dispatch(push(encode));
-    history.push(encode);
   };
 
   return (

--- a/src/components/organisms/BookSearcher/BookSearcher.tsx
+++ b/src/components/organisms/BookSearcher/BookSearcher.tsx
@@ -37,7 +37,6 @@ export const BookSearcher = (props: BookSearchProps) => {
       .join("&");
     const encode = encodeURI(`/book-lists?${keys}&page=1`);
     dispatch(push(encode));
-    props.history.push(encode);
   };
 
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/src/components/organisms/BorrowButton/BorrowButton.tsx
+++ b/src/components/organisms/BorrowButton/BorrowButton.tsx
@@ -61,7 +61,6 @@ export const BorrowButton = (props: BorrowButtonProps) => {
     sendBorrowerName();
     const encode = encodeURI(`/book-detail/${bookId}`);
     dispatch(push(encode));
-    props.history.push(encode);
   };
 
   const [showModal, hideModal] = useModal(

--- a/src/components/organisms/ResultLists/ResultLists.tsx
+++ b/src/components/organisms/ResultLists/ResultLists.tsx
@@ -123,7 +123,6 @@ export const ResultLists = (props: ResultListsProps) => {
       `page=${e.currentTarget.value}`
     )}`;
     dispatch(push(encode));
-    props.history.push(encode);
     // ページ上部に戻す
     window.scrollTo(0, 0);
   };

--- a/src/components/organisms/ReturnButton/ReturnButton.tsx
+++ b/src/components/organisms/ReturnButton/ReturnButton.tsx
@@ -60,7 +60,6 @@ export const ReturnButton = (props: ReturnButtonProps) => {
     sendReturnerName();
     const encode = encodeURI(`/book-detail/${bookId}`);
     dispatch(push(encode));
-    props.history.push(encode);
   };
 
   const [showModal, hideModal] = useModal(

--- a/src/components/pages/routes.tsx
+++ b/src/components/pages/routes.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, lazy } from "react";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { Route, Switch } from "react-router-dom";
 
 const Home = lazy(() => import("../templates/Home"));
 const BookLists = lazy(() => import("../templates/BookLists"));
@@ -11,20 +11,18 @@ const Camera = lazy(() => import("../templates/Camera"));
 const NotFound = lazy(() => import("../templates/NotFound"));
 
 const routes = (
-  <Router>
-    <Suspense fallback={null}>
-      <Switch>
-        <Route exact path="/" component={Home} />
-        <Route path="/book-lists" component={BookLists} />
-        <Route path="/book-detail" component={BookDetail} />
-        <Route path="/borrow" component={Borrow} />
-        <Route path="/return" component={Return} />
-        <Route path="/review" component={Review} />
-        <Route path="/camera" component={Camera} />
-        <Route component={NotFound} />
-      </Switch>
-    </Suspense>
-  </Router>
+  <Suspense fallback={null}>
+    <Switch>
+      <Route exact path="/" component={Home} />
+      <Route path="/book-lists" component={BookLists} />
+      <Route path="/book-detail" component={BookDetail} />
+      <Route path="/borrow" component={Borrow} />
+      <Route path="/return" component={Return} />
+      <Route path="/review" component={Review} />
+      <Route path="/camera" component={Camera} />
+      <Route component={NotFound} />
+    </Switch>
+  </Suspense>
 );
 
 export default routes;


### PR DESCRIPTION
`dispatch(push(encode));`だけでは遷移せず，`history.push(encode);`を併用していたためブラウザとしては2回遷移したことになっていた．
[teratailの回答](https://teratail.com/questions/216393)を参考に`BrowserRouter`を削除した．