### PR TITLE
CircleCIのnodeバージョンアップ

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:12.7.0
+      - image: cimg/node:16.18.1
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images


### PR DESCRIPTION
circleci/nodeは古くなっていたため，後継のcimg/nodeを使用