### PR TITLE
ページネーションの表示数を制限

### DIFF
--- a/src/components/molecules/PageNatior/PageNatior.tsx
+++ b/src/components/molecules/PageNatior/PageNatior.tsx
@@ -15,7 +15,43 @@ export const PageNatior = ({
 }: PageNatiorProps) => {
   const innerPage = () => {
     const items = [];
-    for (let idx = 1; idx <= totalPage; idx += 1) {
+    const limit = 5;
+    let startPage;
+    let endPage;
+    if (currentPage <= Math.ceil(limit / 2)) {
+      startPage = 1;
+      endPage = limit;
+    } else if (
+      currentPage > Math.ceil(limit / 2) &&
+      currentPage <= totalPage - Math.ceil(limit / 2) - 1
+    ) {
+      startPage = currentPage - Math.floor(limit / 2);
+      endPage = currentPage + Math.ceil(limit / 2) - 1;
+    } else {
+      startPage = totalPage - limit + 1;
+      endPage = totalPage;
+    }
+    if (totalPage < limit) {
+      startPage = 1;
+      endPage = totalPage;
+    }
+
+    if (currentPage > 1) {
+      items.push(
+        <li key={0}>
+          <button
+            type="button"
+            tabIndex={0}
+            onClick={handleClick}
+            className={styles.ListButton}
+            value={currentPage - 1}
+          >
+            {"<"}
+          </button>
+        </li>
+      );
+    }
+    for (let idx = startPage; idx <= endPage; idx += 1) {
       items.push(
         <li key={idx}>
           <button
@@ -29,6 +65,21 @@ export const PageNatior = ({
             disabled={(() => idx === currentPage)()}
           >
             {idx}
+          </button>
+        </li>
+      );
+    }
+    if (currentPage < totalPage) {
+      items.push(
+        <li key={totalPage + 1}>
+          <button
+            type="button"
+            tabIndex={0}
+            onClick={handleClick}
+            className={styles.ListButton}
+            value={currentPage + 1}
+          >
+            {">"}
           </button>
         </li>
       );

--- a/src/components/organisms/ResultLists/ResultLists.tsx
+++ b/src/components/organisms/ResultLists/ResultLists.tsx
@@ -108,6 +108,7 @@ export const ResultLists = () => {
       `page=${e.currentTarget.value}`
     )}`;
     dispatch(push(encode));
+    e.currentTarget.blur();
     // ページ上部に戻す
     window.scrollTo(0, 0);
   };


### PR DESCRIPTION
ページ数が多い場合にすべて表示されてはみ出ていた問題を修正
* 表示数は5
* 左右を除き，現在のページが真ん中
* 前のページ，次のページボタンは押すことができない場面では非表示