### PR TITLE
npm installの際のforce削除と.envの雛形を追加

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+REACT_APP_API_HOST="http://<host>:1313/api/v1"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM node:16.17.1-slim AS builder
 WORKDIR /app
 
 COPY . .
-RUN npm install --force && npm run build --production
+RUN npm install && npm run build --production
 
 FROM node:16.17.1-slim
 


### PR DESCRIPTION
* Docker環境構築時に依存関係が壊れていて`npm install`ができなかったため付けていた`--force`を削除
* .envファイルがないとDocker環境でAPIサーバにアクセスできないため，雛形のファイルを追加